### PR TITLE
Add automatic message to MS Teams by pull-request

### DIFF
--- a/.github/workflows/PULL_REQUEST.yaml
+++ b/.github/workflows/PULL_REQUEST.yaml
@@ -1,0 +1,25 @@
+name: Microsoft Teams Notification (Pull-Request)
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  send_notification:
+    name: Pull-Request Notification
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Check GitHub Repository
+        uses: actions/checkout@v3.5.2
+
+      - name: Send Teams Notification
+        uses: mikesprague/teams-incoming-webhook-action@v1
+        with:
+          github-token: ${{ github.token }}
+          webhook-url: ${{ secrets.MS_TEAMS_WEBHOOK_URL }}
+          title: 'Verzoek om pull-request te reviewen'
+          message: |
+             ${{ github.actor }} heeft een pull-request aangemaakt (${{ github.event.pull_request.title }})! \
+             Klik [hier](${{ github.event.pull_request.html_url }}) om naar de pagina van de pull-request te gaan.


### PR DESCRIPTION
Deze workflow zorgt ervoor dat automatisch een melding in de Microsoft Teams omgeving verschijnt bij een nieuwe pull-request. Hierdoor hoeft niet telkens handmatig een bericht gestuurd geworden in de chat dat een pull-request is aangemaakt.
 
Op het moment zal dit alleen voor pull-requests zijn die betrekking hebben op de **dev** branch. Wanneer deze workflow file ook naar de **main** branch is gepusht dan worden ook meldingen in Teams weergegeven m.b.t. die branch. 